### PR TITLE
[A test PR] Add github 'code owners' file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+
+.gitlab-ci.yml @tswilliams @alessandrothea
+
+/tests/ @tswilliams @alessandrothea
+
+/.github/ @tswilliams @alessandrothea
+
+


### PR DESCRIPTION
This pull request adds github 'code owners' file.

(Part of testing of new 'repo manager' scripts.)